### PR TITLE
test case for broken include + print in forloop

### DIFF
--- a/t/interpreter.t
+++ b/t/interpreter.t
@@ -465,3 +465,30 @@ GET /t
 --- no_error_log
 [error]
 
+
+=== TEST 19: 'for include print variable endfor' tag.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local InterpreterContext = Liquid.InterpreterContext
+            local FileSystem = Liquid.FileSystem
+            function FileSystem.get(location) return location end
+            local document = "{% for v in values %} {% include v %} = {{ v }}{% endfor %}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret(InterpreterContext:new({ values = { 'one', 'two' } })))
+        }
+    }
+--- request
+GET /t
+--- response_body
+ one = one two = two
+
+--- no_error_log
+[error]


### PR DESCRIPTION
Looks like when printing variable after calling include it is empty. Just changing the order to print and include fixes it. 