### PR TITLE
Lazy:new has default value of fields

### DIFF
--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -2576,7 +2576,7 @@ function Lazy:new( obj, fields )
     -- body
     local instance = {}
     instance.obj = obj
-    instance.fields = fields
+    instance.fields = fields or {}
     instance.flags = {}
     setmetatable(instance, {
         __index = function ( t, k )

--- a/t/lazy.t
+++ b/t/lazy.t
@@ -72,3 +72,29 @@ hi
 pong
 --- no_error_log
 [error]
+
+
+=== TEST 3: lazy method initialized without cache
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+		 local Liquid = require 'liquid'
+		 local Lazy = Liquid.Lazy
+		 local function ping(...)
+			ngx.say("hi")
+			return "pong"
+		 end
+		 local obj = { ["test"] = ping}
+		 local lazy_oj = Lazy:new(obj)
+		 ngx.say(lazy_oj.test)
+		 ngx.say(lazy_oj.test)
+		}
+	}
+--- request
+GET /t
+--- response_body
+nil
+nil
+--- no_error_log
+[error]


### PR DESCRIPTION
so it does not crash on uninitialized table