### PR TITLE
injectable filesystem

### DIFF
--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -171,8 +171,8 @@ local KEYWORDS = {
 }
 
 --Raw string mode 0;  liquid code mode 1
-RMODE = 0
-CMODE = 1
+local RMODE = 0
+local CMODE = 1
 -- Lexer
 -- local Lexer = {}
 --
@@ -2686,12 +2686,14 @@ function Template:parse( text , parser_context)
     instance.interpreter = Interpreter:new(instance.parser)
     return instance
 end
-function Template:render( context, filterset, resourcelimit )
+function Template:render( context, filterset, resourcelimit, filesystem )
     -- body
     local t_interpretercontext = context or InterpreterContext:new({})
     local t_filterset = filterset or FilterSet:new()
     local t_resourcelimit = resourcelimit or ResourceLimit:new()
-    return self.interpreter:interpret( t_interpretercontext, t_filterset, t_resourcelimit )
+    local t_filesystem = filesystem or FileSystem:new()
+
+    return self.interpreter:interpret( t_interpretercontext, t_filterset, t_resourcelimit, t_filesystem )
 end
 ------------------------------------------------------------- friendly interface end ---------------------------------------------------------
 ------------------------------------------------------------- helper methods begin ---------------------------------------------------------

--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -2549,27 +2549,38 @@ end
 -------------------------------------------------------------ParserContext end ---------------------------------------------------------
 -------------------------------------------------------------FileSystem begin ---------------------------------------------------------
 -- local FileSystem = {}
-function FileSystem:new( get )
+function FileSystem:new( get, error_handler )
     -- body
     local instance = {}
     setmetatable(instance, {__index = FileSystem})
     instance.get = get
     instance.text = nil
+    instance.error_handler = error_handler
     return instance
 end
 --
 function FileSystem:genertic_get( location )
+    local error_handler = self.error_handler
     -- body
     if self.get and type(self.get) == "function" then
-        local status, err = pcall(self.get, location)
-        if status then
-            return err
+        local ok, ret = pcall(self.get, location)
+
+        if not ret then
+            return error_handler(location, "cannot render empty template" )
+	      end
+
+        if ok then
+            return ret
         else
-            error("get template: " .. location .. " fail by user self defined get method " .. tostring(err))
+            return error_handler(location, "fail by user self defined get method: " .. tostring(ret))
         end
     else
-         error("method to get template file is not defined !!")
+        return error_handler(location, "method to get template file is not defined !!")
     end
+end
+--
+function FileSystem.error_handler(location, err)
+    return error(string.format("error when getting template %q: %s", location, err))
 end
 -------------------------------------------------------------FileSystem end ---------------------------------------------------------
 -------------------------------------------------------------Lazy begin ---------------------------------------------------------

--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -2565,14 +2565,12 @@ function FileSystem:generic_get( location )
     if self.get and type(self.get) == "function" then
         local ok, ret = pcall(self.get, location)
 
-        if not ret then
+        if ok and ret then
+            return tostring(ret)
+        elseif ok then
             return error_handler(location, "cannot render empty template" )
-	      end
-
-        if ok then
-            return ret
         else
-            return error_handler(location, "fail by user self defined get method: " .. tostring(ret))
+            return error_handler(location, ret)
         end
     else
         return error_handler(location, "method to get template file is not defined !!")

--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -81,7 +81,7 @@ local CAPTURE = "CAPTURE"       --"capture"
 local ENDCAPTURE = "ENDCAPTURE" --"endcapture"
 local INCREMENT = "INCREMENT"   --"increment"
 local DECREMENT = "DECREMENT"   --"decrement"
--- Genertic token
+-- Generic token
 local NUM = "NUM"
 local STRING = "STRING"
 local ID = "ID"
@@ -1908,11 +1908,11 @@ function Interpreter:visit( node )
     elseif self[method] and type(self[method]) == 'function' then
         return self[method](self, node)
     else
-        return self:genertic_visit(node)
+        return self:generic_visit(node)
     end
 end
 --
-function Interpreter:genertic_visit( node )
+function Interpreter:generic_visit( node )
     -- body
     error('visit_' .. node:_name_() .. ' method not found')
 end
@@ -2386,7 +2386,7 @@ function Interpreter:visit_Partial( node )
     local filesystem = self.filesystem
     local t = node.parser_context
     local location = self:visit(node.location)
-    local file = filesystem:genertic_get(location)
+    local file = filesystem:generic_get(location)
     local lexer = Lexer:new(file)
     local parser = Parser:new(lexer, node.parser_context)
     local context = self.interpretercontext
@@ -2559,7 +2559,7 @@ function FileSystem:new( get, error_handler )
     return instance
 end
 --
-function FileSystem:genertic_get( location )
+function FileSystem:generic_get( location )
     local error_handler = self.error_handler
     -- body
     if self.get and type(self.get) == "function" then

--- a/t/interpreter.t
+++ b/t/interpreter.t
@@ -625,7 +625,7 @@ error when getting template "missing_template": cannot render empty template
 --- request
 GET /t
 --- response_body_like chomp
-error when getting template "error": fail by user self defined get method:
+failed to load location error
 --- no_error_log
 [error]
 
@@ -659,6 +659,6 @@ error when getting template "error": fail by user self defined get method:
 --- request
 GET /t
 --- response_body_like chomp
-location: "error", error: fail by user self defined get method:
+failed to load location error
 --- no_error_log
 [error]


### PR DESCRIPTION
so every interpreter instance can have own filesystem


create custom filesystem like:
```lua
local get = function(location)
  local file, err = io.open(location, 'r')
  if file then
    local contents = file:read('*a')
    file:close()
    return contents
  else
    return nil, err
  end
end

local filesystem = Liquid.FileSystem:new(get)

return interpreter:interpret(context, nil, nil, filesystem)
```

I guess there could be better interface to pass the filesystem into the interpreter, but I think this is ok now.
