### PR TITLE
Integrate CodeClimate (luacheck)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,12 @@
+---
+engines:
+  luacheck:
+    enabled: true
+    channel: beta
+    checks:
+      LC631: # line length
+        enabled: false
+ratings:
+  paths:
+    - '**/*.lua'
+exclude_paths: []

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,1 @@
+std = 'ngx_lua+lua52'

--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -171,8 +171,8 @@ local KEYWORDS = {
 }
 
 --Raw string mode 0;  liquid code mode 1
-RMODE = 0
-CMODE = 1
+local RMODE = 0
+local CMODE = 1
 -- Lexer
 -- local Lexer = {}
 --
@@ -432,7 +432,7 @@ function Lexer:string( ... )
         self:advance()
         while self.current_char do
             if self.current_char:find('\\') then
-                t = self:peek(1)
+                local t = self:peek(1)
                 if t then
                     if t == 'a' then
                         self:advance()
@@ -496,7 +496,7 @@ function Lexer:string( ... )
         self:advance()
         while self.current_char do
             if self.current_char:find('\\') then
-                t = self:peek(1)
+                local t = self:peek(1)
                 if t then
                     if t == 'a' then
                         self:advance()
@@ -2468,7 +2468,7 @@ function Interpreter:visit_IncDec( node)
         inc_dec_context:define_var(node.id, result, 1)
         return result
     else
-        result = 0
+        local result = 0
         inc_dec_context = InterpreterContext:new({})
         inc_dec_context:define_var(node.id, result, 1)
         self.interpretercontext:define_var(IncDec, inc_dec_context, 1)


### PR DESCRIPTION
Run luacheck via CodeClimate.

It discovered few undefined variables and plenty of other issues, but less important.

Another candidate would be the string.lstrip and rstrip. They should be just local functions and not extending global string table

You can see example in my fork: https://codeclimate.com/github/3scale/liquid-lua/pull/3