### PR TITLE
Fixes for the "contains" operator

### DIFF
--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -2078,13 +2078,11 @@ function Interpreter:visit_BinOp( node )
         local right_value = self:visit(node.right)
         if type(right_value) == "string" then
             if type(left_value) == "string" then
-                return string.find(left_value, left_value)
+                return string.find(left_value, right_value)
             elseif type(left_value) == "table" then
-                for i, v in left_value do
-                     if type(v) == "string" then
-                         if string.find(v, right_value) then
-                             return true
-                         end
+                for i, v in ipairs(left_value) do
+                     if type(v) == "string" and v == right_value then
+                        return true
                      end
                 end
                 return false

--- a/t/operators.t
+++ b/t/operators.t
@@ -1,0 +1,102 @@
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (3 * blocks());
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;;";
+    lua_package_cpath "/usr/local/openresty/lualib/?.so;;";
+};
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: 'contains' operator.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local document = "{% if 'abc' contains 'def' %}yes{% else %}no {% endif %}"..
+            "{% if 'abcd' contains 'bc' %}yes {% else %}no{% endif %}"..
+            "{% assign var = 'abc afooa ghi' | split: ' ' %}{% if var contains 'foo' %}yes{% else %}no {% endif %}"..
+            "{% assign var = 'abc def ghi' | split: ' ' %}{% if var contains 'def' %}yes {% else %}no{% endif %}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret())
+        }
+    }
+--- request
+GET /t
+--- response_body
+no yes no yes 
+--- no_error_log
+[error]
+
+=== TEST 2: '==' operator.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local document = "{% if 'abc' == 'def' %}yes{% else %}no {% endif %}"..
+            "{% if 'abcd' == 'abcd' %}yes {% else %}no{% endif %}"..
+            "{% assign var = 'abc def' | split: ' ' %}"..
+            "{% assign var2 = 'abc def ghi' | split: ' ' %}"..
+            "{% if var == var2 %}yes{% else %}no {% endif %}"..
+            "{% assign var = 'abc def ghi' | split: ' ' %}"..
+            "{% assign var2 = 'abc def ghi' | split: ' ' %}"..
+            "{% if var == var2 %}yes {% else %}no{% endif %}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret())
+        }
+    }
+--- request
+GET /t
+--- response_body
+no yes no yes 
+--- no_error_log
+[error]
+
+=== TEST 3: '!=' operator.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local document = "{% if 'abc' != 'def' %}yes {% else %}no{% endif %}"..
+            "{% if 'abcd' != 'abcd' %}yes{% else %}no {% endif %}"..
+            "{% assign var = 'abc def' | split: ' ' %}"..
+            "{% assign var2 = 'abc def ghi' | split: ' ' %}"..
+            "{% if var != var2 %}yes {% else %}no{% endif %}"..
+            "{% assign var = 'abc def ghi' | split: ' ' %}"..
+            "{% assign var2 = 'abc def ghi' | split: ' ' %}"..
+            "{% if var != var2 %}yes{% else %}no {% endif %}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret())
+        }
+    }
+--- request
+GET /t
+--- response_body
+yes no yes no 
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR fixes the following problems currently existing with the "contains" operator:

* `contains` on strings always returns true, e.g.: `{% if "abcdef" contains "wxyz" %}yes{% else %}no{% endif %}` returns `yes`
* `contains` on arrays (tables) behaves incorrectly by iterating through each element of the array and checking whether the argument exists as a substring of each, rather than looking for an exact match, e.g.: `{% assign arr = "abcd afooa efghi" | split: " " %}{% if arr contains "foo" %}yes{% else %}no{% endif%}` returns `yes`